### PR TITLE
fix: 비밀번호 찾기 - 인증코드 에러 메시지 문구 수정

### DIFF
--- a/capstone/src/main/kotlin/com/kmouit/capstone/api/AuthController.kt
+++ b/capstone/src/main/kotlin/com/kmouit/capstone/api/AuthController.kt
@@ -88,7 +88,7 @@ class AuthController(
             }
             VerificationResult.EXPIRED -> {
                 ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(mapOf("message" to "인증코드 유효시간이 만료되었습니다."))
+                    .body(mapOf("message" to "만료된 인증코드입니다."))
             }
         }
     }


### PR DESCRIPTION
변경 전: 인증코드 유효시간이 만료되었습니다.
변경 후: 만료된 인증코드입니다.